### PR TITLE
Add network watcher flow log

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,8 @@
+# Unreleased
+
+Added
+  * GH-2: Add network watcher flow log
+
 # v5.1.0 - 2022-02-03
 
 Added

--- a/examples/main/modules.tf
+++ b/examples/main/modules.tf
@@ -15,8 +15,37 @@ module "rg" {
   stack       = var.stack
 }
 
+module "logs" {
+  source  = "claranet/run-common/azurerm//modules/logs"
+  version = "x.x.x"
+
+  resource_group_name = module.rg.resource_group_name
+
+  client_name    = var.client_name
+  environment    = var.environment
+  location       = var.location
+  location_short = module.azure_region.location_short
+  stack          = var.stack
+
+  # Log analytics
+  log_analytics_workspace_custom_name       = module.naming.log_analytics_workspace.name
+  log_analytics_workspace_retention_in_days = 90
+
+  # Log storage account
+  logs_storage_account_enable_https_traffic_only         = true
+  logs_storage_min_tls_version                           = "TLS1_2"
+  logs_storage_account_enable_advanced_threat_protection = true
+
+  logs_storage_account_enable_archiving                      = true
+  tier_to_cool_after_days_since_modification_greater_than    = 30
+  tier_to_archive_after_days_since_modification_greater_than = 90
+  delete_after_days_since_modification_greater_than          = 2560 # 7 years
+
+  extra_tags = local.extra_tags
+}
+
 data "azurerm_network_watcher" "network_watcher" {
-  name                = "NetworkWatcher_eeastus"
+  name                = "NetworkWatcher_eastus"
   resource_group_name = "NetworkWatcherRG"
 }
 
@@ -42,24 +71,27 @@ module "network_security_group" {
   allowed_ssh_source  = "VirtualNetwork"
 
   # You can set either a prefix for generated name or a custom one for the resource naming
-  #custom_network_security_group_names = "my_nsg"
+  # custom_network_security_group_names = "my_nsg"
 
   # You can set either a prefix for generated name or a custom one for the resource naming
   custom_network_watcher_flow_log_name = "my_nw_flow_log"
 
-  flow_log_enabled            = true
-  flow_log_logging_enabled    = true
-  flow_log_storage_account_id = "xxx"
-  network_watcher_name        = data.azurerm_network_watcher.network_watcher
+  flow_log_enabled         = true
+  flow_log_logging_enabled = true
+
+  network_watcher_name                = data.azurerm_network_watcher.network_watcher.name
+  networK_watcher_resource_group_name = data.azurerm_network_watcher.network_watcher.resource_group_name
 
   flow_log_retention_policy_enabled = true # default to true
   flow_log_retention_policy_days    = 7    # default to 7
 
+  flow_log_storage_account_id                    = module.logs.logs_storage_account_id
   flow_log_traffic_analytics_enabled             = true # default to false
-  log_analytics_workspace_guid                   = "xxx"
-  log_analytics_workspace_location               = "eastus"
-  log_analytics_workspace_id                     = "xxx"
-  flow_log_traffic_analytics_interval_in_minutes = 10 # default to 10
+  flow_log_traffic_analytics_interval_in_minutes = 10   # default to 10
+
+  log_analytics_workspace_guid     = module.logs.log_analytics_workspace_guid
+  log_analytics_workspace_location = module.rg.location
+  log_analytics_workspace_id       = module.logs.log_analytics_workspace_id
 }
 
 # Single port and prefix sample

--- a/examples/main/modules.tf
+++ b/examples/main/modules.tf
@@ -15,6 +15,11 @@ module "rg" {
   stack       = var.stack
 }
 
+data "azurerm_network_watcher" "network_watcher" {
+  name                = "NetworkWatcher_eeastus"
+  resource_group_name = "NetworkWatcherRG"
+}
+
 module "network_security_group" {
   source  = "claranet/nsg/azurerm"
   version = "x.x.x"
@@ -38,6 +43,23 @@ module "network_security_group" {
 
   # You can set either a prefix for generated name or a custom one for the resource naming
   #custom_network_security_group_names = "my_nsg"
+
+  # You can set either a prefix for generated name or a custom one for the resource naming
+  custom_network_watcher_flow_log_name = "my_nw_flow_log"
+
+  flow_log_enabled            = true
+  flow_log_logging_enabled    = true
+  flow_log_storage_account_id = "xxx"
+  network_watcher_name        = data.azurerm_network_watcher.network_watcher
+
+  flow_log_retention_policy_enabled = true # default to true
+  flow_log_retention_policy_days    = 7    # default to 7
+
+  flow_log_traffic_analytics_enabled             = true # default to false
+  log_analytics_workspace_guid                   = "xxx"
+  log_analytics_workspace_location               = "eastus"
+  log_analytics_workspace_id                     = "xxx"
+  flow_log_traffic_analytics_interval_in_minutes = 10 # default to 10
 }
 
 # Single port and prefix sample

--- a/locals-naming.tf
+++ b/locals-naming.tf
@@ -3,5 +3,6 @@ locals {
   name_prefix = lower(var.name_prefix)
   name_suffix = lower(var.name_suffix)
 
-  nsg_name = coalesce(var.custom_network_security_group_name, azurecaf_name.nsg.result)
+  nsg_name      = coalesce(var.custom_network_security_group_name, azurecaf_name.nsg.result)
+  flow_log_name = coalesce(var.custom_network_watcher_flow_log_name, azurecaf_name.nwflog.result)
 }

--- a/outputs.tf
+++ b/outputs.tf
@@ -8,3 +8,7 @@ output "network_security_group_name" {
   value       = azurerm_network_security_group.nsg.name
 }
 
+output "netowrk_watcher_flow_log_id" {
+  description = "Netowrk watcher flow log id"
+  value       = var.flow_log_enabled ? azurerm_network_watcher_flow_log.nwfl[0].id : null
+}

--- a/r-flow-log.tf
+++ b/r-flow-log.tf
@@ -1,0 +1,24 @@
+resource "azurerm_network_watcher_flow_log" "nwfl" {
+  count = var.flow_log_enabled ? 1 : 0
+
+  name                 = local.flow_log_name
+  network_watcher_name = var.network_watcher_name
+  resource_group_name  = var.network_watcher_resource_group_name
+
+  network_security_group_id = azurerm_network_security_group.nsg.id
+  storage_account_id        = var.flow_log_storage_account_id
+  enabled                   = var.flow_log_logging_enabled
+
+  retention_policy {
+    enabled = var.flow_log_retention_policy_enabled
+    days    = var.flow_log_retention_policy_days
+  }
+
+  traffic_analytics {
+    enabled               = var.flow_log_traffic_analytics_enabled
+    workspace_id          = var.log_analytics_workspace_guid
+    workspace_region      = var.log_analytics_workspace_location
+    workspace_resource_id = var.log_analytics_workspace_id
+    interval_in_minutes   = var.flow_log_traffic_analytics_interval_in_minutes
+  }
+}

--- a/r-naming.tf
+++ b/r-naming.tf
@@ -7,3 +7,13 @@ resource "azurecaf_name" "nsg" {
   clean_input   = true
   separator     = "-"
 }
+
+resource "azurecaf_name" "nwflog" {
+  name          = var.stack
+  resource_type = "azurerm_resource_group"
+  prefixes      = compact([local.name_prefix, var.use_caf_naming ? "nwflog" : ""])
+  suffixes      = compact([var.client_name, var.location_short, var.environment, local.name_suffix, var.use_caf_naming ? "" : "nwflog"])
+  use_slug      = false
+  clean_input   = true
+  separator     = "-"
+}

--- a/variables-flowlog.tf
+++ b/variables-flowlog.tf
@@ -1,0 +1,71 @@
+variable "flow_log_enabled" {
+  description = "Provision network watcher flow logs"
+  type        = bool
+  default     = false
+}
+
+variable "flow_log_logging_enabled" {
+  description = "Enable Network Flow Logging"
+  type        = bool
+  default     = true
+}
+
+variable "network_watcher_name" {
+  description = "The name of the Network Watcher. Changing this forces a new resource to be created."
+  type        = string
+  default     = null
+}
+
+variable "network_watcher_resource_group_name" {
+  description = "The name of the resource group in which the Network Watcher was deployed. Changing this forces a new resource to be created."
+  type        = string
+  default     = null
+}
+
+variable "flow_log_storage_account_id" {
+  description = "Network watcher flow log storage account id"
+  type        = string
+  default     = null
+}
+
+variable "flow_log_retention_policy_enabled" {
+  description = "Boolean flag to enable/disable retention"
+  type        = bool
+  default     = true
+}
+
+variable "flow_log_retention_policy_days" {
+  description = "The number of days to retain flow log records"
+  type        = number
+  default     = 7
+}
+
+variable "flow_log_traffic_analytics_enabled" {
+  description = "Boolean flag to enable/disable traffic analytics"
+  type        = bool
+  default     = true
+}
+
+variable "log_analytics_workspace_guid" {
+  description = "The resource GUID of the attached workspace."
+  type        = string
+  default     = null
+}
+
+variable "log_analytics_workspace_location" {
+  description = "The location of the attached workspace."
+  type        = string
+  default     = null
+}
+
+variable "log_analytics_workspace_id" {
+  description = "The resource ID of the attached workspace."
+  type        = string
+  default     = null
+}
+
+variable "flow_log_traffic_analytics_interval_in_minutes" {
+  description = "How frequently service should do flow analytics in minutes."
+  type        = number
+  default     = 10
+}

--- a/variables-naming.tf
+++ b/variables-naming.tf
@@ -23,3 +23,9 @@ variable "custom_network_security_group_name" {
   type        = string
   default     = null
 }
+
+variable "custom_network_watcher_flow_log_name" {
+  description = "Network watcher flow log name."
+  type        = string
+  default     = null
+}


### PR DESCRIPTION
Since it's recommended to always have a network watcher flow log enabled for nsg, I think it's nice to have it attached here, instead of declaring it separately each time.