### PR TITLE
Set `location` and `tags` explicitly to avoid state mismatch

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,6 +7,13 @@ with possible predefined rules.
 
 The default module configuration deny all inbound traffic.
 
+## When Flow Logs are enabled
+
+Make sure to use a Storage Account with no existing lifecycle management rules
+as this will add a new rule and overwrite the existing ones.
+
+Fore more details, see https://github.com/hashicorp/terraform-provider-azurerm/issues/6935.
+
 <!-- BEGIN_TF_DOCS -->
 ## Global versioning rule for Claranet Azure modules
 
@@ -125,7 +132,7 @@ module "network_security_group" {
   network_watcher_resource_group_name = data.azurerm_network_watcher.network_watcher.resource_group_name
 
   flow_log_retention_policy_enabled = true # default to true
-  flow_log_retention_policy_days    = 91    # default to 91
+  flow_log_retention_policy_days    = 91   # default to 91
 
   # Make sure to use a storage account with no existing lifecycle management rules
   # as this will adds a new rule and overwrites the existing one.
@@ -201,6 +208,7 @@ No modules.
 | [azurerm_network_security_rule.ssh_inbound](https://registry.terraform.io/providers/hashicorp/azurerm/latest/docs/resources/network_security_rule) | resource |
 | [azurerm_network_security_rule.winrm_inbound](https://registry.terraform.io/providers/hashicorp/azurerm/latest/docs/resources/network_security_rule) | resource |
 | [azurerm_network_watcher_flow_log.nwfl](https://registry.terraform.io/providers/hashicorp/azurerm/latest/docs/resources/network_watcher_flow_log) | resource |
+| [azurerm_network_watcher.nw](https://registry.terraform.io/providers/hashicorp/azurerm/latest/docs/data-sources/network_watcher) | data source |
 
 ## Inputs
 
@@ -220,8 +228,9 @@ No modules.
 | environment | Project environment | `string` | n/a | yes |
 | extra\_tags | Additional tags to associate with your Network Security Group. | `map(string)` | `{}` | no |
 | flow\_log\_enabled | Provision network watcher flow logs | `bool` | `false` | no |
+| flow\_log\_location | The location where the Network Watcher Flow Log resides. Changing this forces a new resource to be created. Defaults to the `location` of the Network Watcher. | `string` | `null` | no |
 | flow\_log\_logging\_enabled | Enable Network Flow Logging | `bool` | `true` | no |
-| flow\_log\_retention\_policy\_days | The number of days to retain flow log records | `number` | `7` | no |
+| flow\_log\_retention\_policy\_days | The number of days to retain flow log records | `number` | `91` | no |
 | flow\_log\_retention\_policy\_enabled | Boolean flag to enable/disable retention | `bool` | `true` | no |
 | flow\_log\_storage\_account\_id | Network watcher flow log storage account id | `string` | `null` | no |
 | flow\_log\_traffic\_analytics\_enabled | Boolean flag to enable/disable traffic analytics | `bool` | `true` | no |

--- a/README.md
+++ b/README.md
@@ -73,6 +73,19 @@ module "logs" {
   }
 }
 
+module "storage_account" {
+  source  = "claranet/storage-account/azurerm"
+  version = "x.x.x"
+
+  location       = module.azure_region.location
+  location_short = module.azure_region.location_short
+  client_name    = var.client_name
+  environment    = var.environment
+  stack          = var.stack
+
+  resource_group_name = module.rg.resource_group_name
+}
+
 data "azurerm_network_watcher" "network_watcher" {
   name                = "NetworkWatcher_${module.azure_region.location_cli}"
   resource_group_name = "NetworkWatcherRG"
@@ -114,7 +127,10 @@ module "network_security_group" {
   flow_log_retention_policy_enabled = true # default to true
   flow_log_retention_policy_days    = 7    # default to 7
 
-  flow_log_storage_account_id                    = module.logs.logs_storage_account_id
+  # Make sure to use a storage account with no existing lifecycle management rules
+  # as this will adds a new rule and overwrites the existing one.
+  # Fore more details, see https://github.com/hashicorp/terraform-provider-azurerm/issues/6935
+  flow_log_storage_account_id                    = module.storage_account.storage_account_id
   flow_log_traffic_analytics_enabled             = true # default to false
   flow_log_traffic_analytics_interval_in_minutes = 10   # default to 10
 

--- a/README.md
+++ b/README.md
@@ -125,7 +125,7 @@ module "network_security_group" {
   network_watcher_resource_group_name = data.azurerm_network_watcher.network_watcher.resource_group_name
 
   flow_log_retention_policy_enabled = true # default to true
-  flow_log_retention_policy_days    = 7    # default to 7
+  flow_log_retention_policy_days    = 91    # default to 91
 
   # Make sure to use a storage account with no existing lifecycle management rules
   # as this will adds a new rule and overwrites the existing one.

--- a/examples/main/modules.tf
+++ b/examples/main/modules.tf
@@ -45,6 +45,19 @@ module "logs" {
   }
 }
 
+module "storage_account" {
+  source  = "claranet/storage-account/azurerm"
+  version = "x.x.x"
+
+  location       = module.azure_region.location
+  location_short = module.azure_region.location_short
+  client_name    = var.client_name
+  environment    = var.environment
+  stack          = var.stack
+
+  resource_group_name = module.rg.resource_group_name
+}
+
 data "azurerm_network_watcher" "network_watcher" {
   name                = "NetworkWatcher_${module.azure_region.location_cli}"
   resource_group_name = "NetworkWatcherRG"
@@ -86,7 +99,10 @@ module "network_security_group" {
   flow_log_retention_policy_enabled = true # default to true
   flow_log_retention_policy_days    = 7    # default to 7
 
-  flow_log_storage_account_id                    = module.logs.logs_storage_account_id
+  # Make sure to use a storage account with no existing lifecycle management rules
+  # as this will adds a new rule and overwrites the existing one.
+  # Fore more details, see https://github.com/hashicorp/terraform-provider-azurerm/issues/6935
+  flow_log_storage_account_id                    = module.storage_account.storage_account_id
   flow_log_traffic_analytics_enabled             = true # default to false
   flow_log_traffic_analytics_interval_in_minutes = 10   # default to 10
 

--- a/examples/main/modules.tf
+++ b/examples/main/modules.tf
@@ -97,7 +97,7 @@ module "network_security_group" {
   network_watcher_resource_group_name = data.azurerm_network_watcher.network_watcher.resource_group_name
 
   flow_log_retention_policy_enabled = true # default to true
-  flow_log_retention_policy_days    = 7    # default to 7
+  flow_log_retention_policy_days    = 91   # default to 91
 
   # Make sure to use a storage account with no existing lifecycle management rules
   # as this will adds a new rule and overwrites the existing one.

--- a/r-flow-log.tf
+++ b/r-flow-log.tf
@@ -1,13 +1,20 @@
+data "azurerm_network_watcher" "nw" {
+  name                = var.network_watcher_name
+  resource_group_name = var.network_watcher_resource_group_name
+}
+
 resource "azurerm_network_watcher_flow_log" "nwfl" {
   count = var.flow_log_enabled ? 1 : 0
 
   name                 = local.flow_log_name
-  network_watcher_name = var.network_watcher_name
-  resource_group_name  = var.network_watcher_resource_group_name
+  network_watcher_name = data.azurerm_network_watcher.nw.name
+  resource_group_name  = data.azurerm_network_watcher.nw.resource_group_name
 
   network_security_group_id = azurerm_network_security_group.nsg.id
   storage_account_id        = var.flow_log_storage_account_id
   enabled                   = var.flow_log_logging_enabled
+
+  location = coalesce(var.flow_log_location, data.azurerm_network_watcher.nw.location)
 
   retention_policy {
     enabled = var.flow_log_retention_policy_enabled
@@ -21,4 +28,6 @@ resource "azurerm_network_watcher_flow_log" "nwfl" {
     workspace_resource_id = var.log_analytics_workspace_id
     interval_in_minutes   = var.flow_log_traffic_analytics_interval_in_minutes
   }
+
+  tags = local.default_tags
 }

--- a/variables-flowlog.tf
+++ b/variables-flowlog.tf
@@ -37,7 +37,7 @@ variable "flow_log_retention_policy_enabled" {
 variable "flow_log_retention_policy_days" {
   description = "The number of days to retain flow log records"
   type        = number
-  default     = 7
+  default     = 91
 }
 
 variable "flow_log_traffic_analytics_enabled" {

--- a/variables-flowlog.tf
+++ b/variables-flowlog.tf
@@ -69,3 +69,9 @@ variable "flow_log_traffic_analytics_interval_in_minutes" {
   type        = number
   default     = 10
 }
+
+variable "flow_log_location" {
+  description = "The location where the Network Watcher Flow Log resides. Changing this forces a new resource to be created. Defaults to the `location` of the Network Watcher."
+  type        = string
+  default     = null
+}


### PR DESCRIPTION
When `location` (Same for tags) is not set, the network watcher location is used by default, which causes a mismatch between the deployed infra and the value of the `location` in the state. So every run generates a new plan, that changes the location in terraform's state which's `null`.

![Screenshot 2022-09-13 at 10 53 08](https://user-images.githubusercontent.com/22898667/189869474-8473f90f-5185-4b52-9e3f-92fbc76739dc.png)
