### PR TITLE
Set default values for nsg `additional_rules`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,8 @@
+# Unreleased
+
+Added
+  * [GH-4](https://github.com/claranet/terraform-azurerm-nsg/pull/4): Set default values for nsg `additional_rules`
+
 # v7.0.0 - 2022-09-30
 
 Breaking

--- a/variables.tf
+++ b/variables.tf
@@ -151,9 +151,9 @@ variable "additional_rules" {
   type = list(object({
     priority  = number
     name      = string
-    direction = optional(string)
-    access    = optional(string)
-    protocol  = optional(string)
+    direction = optional(string, "Inbound")
+    access    = optional(string, "Allow")
+    protocol  = optional(string, "Tcp")
 
     source_port_range  = optional(string)
     source_port_ranges = optional(list(string))


### PR DESCRIPTION
Now that we're only supporting `terraform ~>1.3`, we can safely to apply the differed change from #1.