### PR TITLE
chore: add var.extra_tags to azurerm_network_watcher_flow_log

### DIFF
--- a/r-flow-log.tf
+++ b/r-flow-log.tf
@@ -31,5 +31,5 @@ resource "azurerm_network_watcher_flow_log" "nwfl" {
     interval_in_minutes   = var.flow_log_traffic_analytics_interval_in_minutes
   }
 
-  tags = local.default_tags
+  tags = merge(local.default_tags, var.extra_tags)
 }


### PR DESCRIPTION
azurerm_network_watcher_flow_log was lacking var.extra_tags in its tags, i add them

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

## Changes proposed in this pull request

-
-
-

@claranet/fr-azure-reviewers
