### PR TITLE
fix: skip `traffic_analytics` vars validation when not enabled

### DIFF
--- a/r-flow-log.tf
+++ b/r-flow-log.tf
@@ -16,12 +16,15 @@ resource "azurerm_network_watcher_flow_log" "main" {
     days    = var.flow_log_retention_policy_days
   }
 
-  traffic_analytics {
-    enabled               = var.flow_log_traffic_analytics_enabled
-    workspace_id          = var.log_analytics_workspace_guid
-    workspace_region      = var.log_analytics_workspace_location
-    workspace_resource_id = var.log_analytics_workspace_id
-    interval_in_minutes   = var.flow_log_traffic_analytics_interval_in_minutes
+  dynamic "traffic_analytics" {
+    for_each = var.flow_log_traffic_analytics_enabled ? ["enabled"] : []
+    content {
+      enabled               = var.flow_log_traffic_analytics_enabled
+      workspace_id          = var.log_analytics_workspace_guid
+      workspace_region      = var.log_analytics_workspace_location
+      workspace_resource_id = var.log_analytics_workspace_id
+      interval_in_minutes   = var.flow_log_traffic_analytics_interval_in_minutes
+    }
   }
 
   tags = merge(local.default_tags, var.extra_tags)


### PR DESCRIPTION
When `traffic_analytics` is not enabled, terraform still validates the variables as they are required.

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

## Changes proposed in this pull request

- Make block dynamic

@claranet/fr-azure-reviewers
